### PR TITLE
Add "Contact Us" link to navigation layout

### DIFF
--- a/PRReviewProject/PRReviewProject/Pages/Shared/_Layout.cshtml
+++ b/PRReviewProject/PRReviewProject/Pages/Shared/_Layout.cshtml
@@ -31,6 +31,9 @@
                         <li class="nav-item">
                             <a class="nav-link text-dark" asp-area="" asp-page="/Product/Index">Products</a>
                         </li>
+                        <li class="nav-item">
+                            <a class="nav-link text-dark" asp-area="" asp-page="/Product/Index">Contact Us</a>
+                        </li>
                     </ul>
                 </div>
             </div>


### PR DESCRIPTION
Introduced a new navigation item for "Contact Us" that links to the "/Product/Index" page, enhancing user access to contact information.